### PR TITLE
Can now add, edit, and delete games

### DIFF
--- a/app/assets/stylesheets/components/_tabs.scss
+++ b/app/assets/stylesheets/components/_tabs.scss
@@ -135,6 +135,10 @@ li {
       color: white;
       text-decoration: none;
     }
+
+  }
+  .delete {
+    background-color: $tertiary;
   }
 
   .invite {

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -13,14 +13,16 @@ class GamesController < ApplicationController
     @game.guild = @guild
 
     if @game.save
-      redirect_to guild_path @guild, notice: 'Game was successfully created.'
+      redirect_to game_path(@game)
     else
       render :new, status: :unprocessable_entity
     end
+    authorize @game
   end
 
   # GET /games/:id/edit
   def edit
+    authorize @game
   end
 
   # PATCH/PUT /games/:id
@@ -30,6 +32,7 @@ class GamesController < ApplicationController
     else
       render :edit
     end
+    authorize @game
   end
 
   # GET /games/:id
@@ -41,8 +44,10 @@ class GamesController < ApplicationController
 
   # DELETE /games/:id
   def destroy
+    @guild = @game.guild
     @game.destroy
-    redirect_to games_path, notice: 'Game was successfully destroyed.'
+    redirect_to guild_path(@guild), notice: 'Game was successfully destroyed.'
+    authorize @game
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  has_many :event_members
+  has_many :event_members, dependent: :destroy
   has_many :members, through: :event_members
 
   belongs_to :guild

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,9 +1,9 @@
 class Game < ApplicationRecord
   belongs_to :guild
-  
-  has_many :game_members
+
+  has_many :game_members, dependent: :destroy
   has_many :members, through: :game_members
-  has_many :events
+  has_many :events, dependent: :destroy
   has_one_attached :game_banner
   has_one_attached :game_icon
 

--- a/app/policies/game_policy.rb
+++ b/app/policies/game_policy.rb
@@ -7,10 +7,26 @@ class GamePolicy < ApplicationPolicy
   end
 
   def show?
-    user.member.games.any?(record)
+    user.member.games.any?(record) || user.member.role == "admin"
   end
 
   def new?
+    user.member.role == "admin"
+  end
+
+  def create?
+    user.member.role == "admin"
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    user.member.role == "admin"
+  end
+
+  def destroy?
     user.member.role == "admin"
   end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -11,7 +11,19 @@
         <p><%= link_to "Events", @source.is_a?(Guild) ? guild_events_path(@guild) : game_events_path(@game), class: "event-btn" %></p>
       </div>
     </div>
+
+    <div class="game-buttons">
+      <div class="tabs">
+        <div class="tab">
+          <p><%= link_to "Edit", edit_game_path(@game) if current_user.member.role == "admin" %></p>
+        </div>
+        <div class="delete tab">
+          <p><%= link_to "Delete", game_path, data: { turbo_method: :delete, turbo_confirm: "Delete this game?" } if current_user.member.role == "admin" %></p>
+        </div>
+      </div>
     </div>
+  </div>
+
       <div class="card-container">
         <div class="game-member-card-wrapper">
         <% @game.members.each do |member| %>


### PR DESCRIPTION
1. Fixed game creation policy - admin can now create games
2. Set up edit - admin can now edit games
3. Set up destroy - admin can now delete games, which destroys all associated game_members/events/event_members also
4. Added edit and delete buttons on game show page that show up if user is admin
5. Added some styling to tabs css for delete button